### PR TITLE
Fix null reference on the destruction of empty Hook

### DIFF
--- a/subhook.h
+++ b/subhook.h
@@ -145,8 +145,10 @@ class Hook {
     : hook_(subhook_new(src, dst, (subhook_options_t)options)) {}
 
   ~Hook() {
-    subhook_remove(hook_);
-    subhook_free(hook_);
+    if (hook_ != 0) {
+      subhook_remove(hook_);
+      subhook_free(hook_);
+    }
   }
 
   void *GetSrc() { return subhook_get_src(hook_); }


### PR DESCRIPTION
I experienced an application crash in the following situation. So I've fixed it.

```cpp
subhook::Hook foo_hook;

int main(void) {
  return 0;
}
```
