### PR TITLE
Add new ScopedHookInstall constructor which can set/override the new hook destination

### DIFF
--- a/subhook.h
+++ b/subhook.h
@@ -217,6 +217,15 @@ class ScopedHookInstall {
   {
   }
 
+  ScopedHookInstall(Hook *hook,
+                    void *src,
+                    void *dst,
+                    HookOptions options = HookOptionsNone)
+    : hook_(hook)
+    , installed_(hook_->Install(src, dst, options))
+  {
+  }
+
   ~ScopedHookInstall() {
     if (installed_) {
       hook_->Remove();


### PR DESCRIPTION
Why ScopedHookInstall does not have a constructor which can specify installation details? I think it would be sometimes useful.

```cpp
subhook::Hook foo_hook;

void foo_fake(void) {
  subhook::ScopedHookRemove foo_remove(&foo_hook);
  foo();
}

int main(void) {
  {
    subhook::ScopedHookInstall foo_install(&foo_hook, foo, foo_fake); // NEW

    do_something();
  }

  return 0;
}
```
