### PR TITLE
docs: fix simple typo, wihtout -> without

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ With CMake:
    * `SUBHOOK_FORCE_32BIT` - Configure for compiling 32-bit binaries on 64-bit
      systems (default is `OFF`)
 
-Use of CMake is not mandatory, the library can be built wihtout it (no extra
+Use of CMake is not mandatory, the library can be built without it (no extra
 build configuration is required).
 
 Examples


### PR DESCRIPTION
There is a small typo in README.md.

Should read `without` rather than `wihtout`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md