### PR TITLE
add SUBHOOK_TRY_ALLOCATE_TRAMPOLINE_NEAR_SOURCE flag

### DIFF
--- a/subhook.h
+++ b/subhook.h
@@ -91,7 +91,9 @@
 
 typedef enum subhook_flags {
   /* Use the 64-bit jump method on x86-64 (requires more space). */
-  SUBHOOK_64BIT_OFFSET = 1
+  SUBHOOK_64BIT_OFFSET = 1,
+  /* Best effort trying to allocate trampoline code near source function. */
+  SUBHOOK_TRY_ALLOCATE_TRAMPOLINE_NEAR_SOURCE = 1 << 1
 } subhook_flags_t;
 
 struct subhook_struct;
@@ -146,7 +148,8 @@ namespace subhook {
 
 enum HookFlags {
   HookNoFlags = 0,
-  HookFlag64BitOffset = SUBHOOK_64BIT_OFFSET
+  HookFlag64BitOffset = SUBHOOK_64BIT_OFFSET,
+  HookFlagTryAllocateTrampolineNearSource = SUBHOOK_TRY_ALLOCATE_TRAMPOLINE_NEAR_SOURCE
 };
 
 inline HookFlags operator|(HookFlags o1, HookFlags o2) {

--- a/subhook_private.h
+++ b/subhook_private.h
@@ -29,6 +29,8 @@
 
 #include <stddef.h>
 
+#include "subhook.h"
+
 #ifndef true
   #define true 1
 #endif
@@ -49,7 +51,7 @@ struct subhook_struct {
 };
 
 int subhook_unprotect(void *address, size_t size);
-void *subhook_alloc_code(size_t size);
+void *subhook_alloc_code(void* src_addr, size_t size, subhook_flags_t flags);
 int subhook_free_code(void *address, size_t size);
 
 #endif /* SUBHOOK_PRIVATE_H */

--- a/subhook_windows.c
+++ b/subhook_windows.c
@@ -27,6 +27,8 @@
 #include <stddef.h>
 #include <windows.h>
 
+#include "subhook_private.h"
+
 #define SUBHOOK_CODE_PROTECT_FLAGS PAGE_EXECUTE_READWRITE
 
 int subhook_unprotect(void *address, size_t size) {
@@ -38,7 +40,7 @@ int subhook_unprotect(void *address, size_t size) {
   return !result;
 }
 
-void *subhook_alloc_code(size_t size) {
+void *subhook_alloc_code(void*, size_t size, subhook_flags_t) {
   return VirtualAlloc(NULL,
                       size,
                       MEM_COMMIT | MEM_RESERVE,

--- a/subhook_x86.c
+++ b/subhook_x86.c
@@ -487,7 +487,9 @@ SUBHOOK_EXPORT subhook_t SUBHOOK_API subhook_new(void *src,
     goto error_exit;
   }
 
-  hook->trampoline = subhook_alloc_code(hook->trampoline_size);
+  hook->trampoline = subhook_alloc_code(hook->src,
+                                        hook->trampoline_size,
+                                        hook->flags);
   if (hook->trampoline != NULL) {
     error = subhook_make_trampoline(hook->trampoline,
                                     hook->src,

--- a/tests/test.c
+++ b/tests/test.c
@@ -33,7 +33,8 @@ int main() {
 
   subhook_t foo_hook = subhook_new((void *)foo,
                                    (void *)foo_hooked,
-                                   SUBHOOK_64BIT_OFFSET);
+                                   SUBHOOK_64BIT_OFFSET
+                                   | SUBHOOK_TRY_ALLOCATE_TRAMPOLINE_NEAR_SOURCE);
   if (foo_hook == NULL || subhook_install(foo_hook) < 0) {
     puts("Install failed");
     return EXIT_FAILURE;
@@ -64,7 +65,8 @@ int main() {
 
   subhook_t foo_hook_tr = subhook_new((void *)foo,
                                       (void *)foo_hooked_tr,
-                                      SUBHOOK_64BIT_OFFSET);
+                                      SUBHOOK_64BIT_OFFSET
+                                      | SUBHOOK_TRY_ALLOCATE_TRAMPOLINE_NEAR_SOURCE);
   if (subhook_install(foo_hook_tr) < 0) {
     puts("Install failed");
     return EXIT_FAILURE;

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -32,7 +32,8 @@ int main() {
 
   subhook::Hook foo_hook((void *)foo,
                          (void *)foo_hooked,
-                         subhook::HookFlag64BitOffset);
+                         subhook::HookFlag64BitOffset
+                         | subhook::HookFlagTryAllocateTrampolineNearSource);
   if (!foo_hook.Install()) {
     std::cout << "Install failed" << std::endl;
     return EXIT_FAILURE;
@@ -61,7 +62,8 @@ int main() {
 
   subhook::Hook foo_hook_tr((void *)foo,
                             (void *)foo_hooked_tr,
-                            subhook::HookFlag64BitOffset);
+                            subhook::HookFlag64BitOffset
+                            | subhook::HookFlagTryAllocateTrampolineNearSource);
   if (!foo_hook_tr.Install()) {
     std::cout << "Install failed" << std::endl;
     return EXIT_FAILURE;


### PR DESCRIPTION
On 64-bit Linux systems, this flag will let subhook call mmap()
with MAP_FIXED_NOREPLACE to allocate trampoline code near the
source function. This helps avoid relocation overflow when
generating trampoline code.

The exact allocation address will be determined by going through
/proc/<pid>/maps file and locating the nearest unmapped address
near the source function.